### PR TITLE
upd8

### DIFF
--- a/Modules/!EZParser.mkape
+++ b/Modules/!EZParser.mkape
@@ -1,7 +1,7 @@
 Description: Eric Zimmerman Parsers
 Category: Modules
 Author: Phill Moore
-Version: 1.2
+Version: 1.3
 Id: f531e7cc-c9f3-4d04-881b-dbc89d1e7f38
 BinaryUrl: https://ericzimmerman.github.io/
 ExportFormat: csv

--- a/Modules/LiveResponse/Get-InjectedThread.mkape
+++ b/Modules/LiveResponse/Get-InjectedThread.mkape
@@ -8,7 +8,7 @@ ExportFormat: json
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "Import-Module %kapedirectory%\Modules\bin\Get-InjectedThread.ps1 -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-InjectedThread.json"
+        CommandLine: -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-InjectedThread.mkape
+++ b/Modules/LiveResponse/Get-InjectedThread.mkape
@@ -8,7 +8,7 @@ ExportFormat: json
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
+        CommandLine: -ep bypass -Command "Import-Module '%kapedirectory%\Modules\bin\Get-InjectedThread.ps1' -Force; Get-InjectedThread | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-InjectedThread.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-NetworkConnection.mkape
+++ b/Modules/LiveResponse/Get-NetworkConnection.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.csv"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
         ExportFormat: csv
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath %destinationDirectory%\Get-NetworkConnection.json"
+        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
         ExportFormat: json
 
 # Documentation

--- a/Modules/LiveResponse/Get-NetworkConnection.mkape
+++ b/Modules/LiveResponse/Get-NetworkConnection.mkape
@@ -8,11 +8,11 @@ ExportFormat: csv
 Processors:
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
+        CommandLine: -ep bypass -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Csv -NoTypeInformation | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.csv'"
         ExportFormat: csv
     -
         Executable: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
-        CommandLine: -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
+        CommandLine: -ep bypass -Command "& '%kapedirectory%\Modules\bin\Get-NetworkConnection.ps1' | ConvertTo-Json  | Out-File -FilePath '%destinationDirectory%\Get-NetworkConnection.json'"
         ExportFormat: json
 
 # Documentation


### PR DESCRIPTION
## Description

Please include a summary of the change and (if applicable) which issue is fixed.

## Checklist:
Please replace every instance of `[ ]` with `[X]`

- [ ] I have generated a unique GUID for my Target(s)/Module(s)
- [ ] I have placed the Target/Module in an appropriate subfolder in Targets or Modules. If one doesn't exist, I have either added it to the Misc folder or created a relevant subfolder **with justification**
- [ ] I have set or updated the version of my Target(s)/Module(s)
- [ ] I have verified that KAPE parses the Target successfully via kape.exe, using `--tlist`/`--mlist` and corrected any errors 
- [ ] I have made an attempt to document the artifacts within the Target(s) or Module(s) I am submitting. If documentation doesn't exist, I have placed N/A underneath the Documentation header
- [ ] I have consulted either the [Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetGuide.guide), [Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/TargetTemplate.template), [Compound Target Guide](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetGuide.guide), or [Compound Target Template](https://github.com/EricZimmerman/KapeFiles/blob/master/Targets/CompoundTargetTemplate.template) to ensure my Target(s) follow the same format

Thank you for your submission and for contributing to the DFIR community!
